### PR TITLE
Remove old correccion-ft naming

### DIFF
--- a/generar-ft-de-fs-application/src/main/java/com/comerzzia/bricodepot/generarftdefs/application/GenerarFtDeFsApplication.java
+++ b/generar-ft-de-fs-application/src/main/java/com/comerzzia/bricodepot/generarftdefs/application/GenerarFtDeFsApplication.java
@@ -6,10 +6,10 @@ import org.springframework.context.annotation.ImportResource;
 
 @ImportResource({"classpath*:comerzzia-*context.xml"})
 @SpringBootApplication
-public class CorreccionFtApplication{
+public class GenerarFtDeFsApplication {
 
-        public static void main(String[] args) {
-                SpringApplication.run(CorreccionFtApplication.class, args);
-        }
+    public static void main(String[] args) {
+        SpringApplication.run(GenerarFtDeFsApplication.class, args);
+    }
 
 }

--- a/generar-ft-de-fs-application/src/main/java/com/comerzzia/bricodepot/generarftdefs/runner/GenerarFtDeFsRunner.java
+++ b/generar-ft-de-fs-application/src/main/java/com/comerzzia/bricodepot/generarftdefs/runner/GenerarFtDeFsRunner.java
@@ -1,6 +1,6 @@
 package com.comerzzia.bricodepot.generarftdefs.runner;
 
-import com.comerzzia.bricodepot.generarftdefs.services.correccion.CorreccionFtService;
+import com.comerzzia.bricodepot.generarftdefs.services.generacion.GenerarFtDeFsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
@@ -9,10 +9,10 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 
 @Component
-public class CorreccionFtRunner implements CommandLineRunner {
+public class GenerarFtDeFsRunner implements CommandLineRunner {
 
     @Autowired
-    private CorreccionFtService servicio;
+    private GenerarFtDeFsService servicio;
 
     @Override
     public void run(String... args) throws Exception {

--- a/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/services/generacion/GenerarFtDeFsService.java
+++ b/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/services/generacion/GenerarFtDeFsService.java
@@ -1,4 +1,4 @@
-package com.comerzzia.bricodepot.generarftdefs.services.correccion;
+package com.comerzzia.bricodepot.generarftdefs.services.generacion;
 
 import com.comerzzia.bricodepot.generarftdefs.persistence.ProveedorConexion;
 import com.comerzzia.bricodepot.generarftdefs.persistence.TicketsDao;
@@ -34,9 +34,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CorreccionFtService {
+public class GenerarFtDeFsService {
 
-    private static final Logger log = LoggerFactory.getLogger(CorreccionFtService.class);
+    private static final Logger log = LoggerFactory.getLogger(GenerarFtDeFsService.class);
 
     @Autowired
     private ProveedorConexion proveedorConexion;


### PR DESCRIPTION
## Summary
- rename CorreccionFtApplication to GenerarFtDeFsApplication
- rename CorreccionFtRunner to GenerarFtDeFsRunner
- rename CorreccionFtService to GenerarFtDeFsService and adjust package

## Testing
- `mvn -q -DskipTests install` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6874bebe57b8832b9bdc6a0585623206