### PR TITLE
Implement automatic albaran removal

### DIFF
--- a/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/TicketsDao.java
+++ b/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/TicketsDao.java
@@ -59,4 +59,84 @@ public class TicketsDao {
                 log.info("actualizarTicket() - " + stmt.toString());
                 stmt.executeUpdate();
         }
+
+        /**
+         * Elimina el albarán asociado al ticket indicado. Se borran todos los
+         * registros dependientes antes de eliminar la cabecera del albarán.
+         */
+        public static void eliminarAlbaran(Connection conexion, String uidActividad, String uidTicket)
+                        throws SQLException {
+                String selectSql = "select id_clie_albaran from d_clie_albaranes_cab_tbl where uid_actividad = ? and uid_ticket = ?";
+                PreparedStatement selectStmt = conexion.prepareStatement(selectSql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+                selectStmt.setString(1, uidActividad);
+                selectStmt.setString(2, uidTicket);
+                log.info("eliminarAlbaran() - " + selectStmt.toString());
+                ResultSet rs = selectStmt.executeQuery();
+                while (rs.next()) {
+                        long idClieAlbaran = rs.getLong("id_clie_albaran");
+
+                        eliminarAlbaranDependencias(conexion, uidActividad, uidTicket, idClieAlbaran);
+
+                        String deleteCab = "delete from d_clie_albaranes_cab_tbl where uid_actividad = ? and id_clie_albaran = ?";
+                        PreparedStatement stmtCab = conexion.prepareStatement(deleteCab);
+                        stmtCab.setString(1, uidActividad);
+                        stmtCab.setLong(2, idClieAlbaran);
+                        log.info("eliminarAlbaran() - " + stmtCab.toString());
+                        stmtCab.executeUpdate();
+                        stmtCab.close();
+                }
+                rs.close();
+                selectStmt.close();
+        }
+
+        private static void eliminarAlbaranDependencias(Connection conexion, String uidActividad, String uidTicket, long idClieAlbaran)
+                        throws SQLException {
+                String sqlVenta = "delete from d_clie_ventas_det_mod_pre_tbl where uid_documento = ? and uid_actividad = ?";
+                PreparedStatement stmtVenta = conexion.prepareStatement(sqlVenta);
+                stmtVenta.setString(1, uidTicket);
+                stmtVenta.setString(2, uidActividad);
+                log.info("eliminarAlbaranDependencias() - " + stmtVenta.toString());
+                stmtVenta.executeUpdate();
+                stmtVenta.close();
+
+                String sqlImp = "delete from d_clie_albaranes_imp_tbl where id_clie_albaran = ? and uid_actividad = ?";
+                PreparedStatement stmtImp = conexion.prepareStatement(sqlImp);
+                stmtImp.setLong(1, idClieAlbaran);
+                stmtImp.setString(2, uidActividad);
+                log.info("eliminarAlbaranDependencias() - " + stmtImp.toString());
+                stmtImp.executeUpdate();
+                stmtImp.close();
+
+                String sqlPag = "delete from d_clie_albaranes_pag_tbl where id_clie_albaran = ? and uid_actividad = ?";
+                PreparedStatement stmtPag = conexion.prepareStatement(sqlPag);
+                stmtPag.setLong(1, idClieAlbaran);
+                stmtPag.setString(2, uidActividad);
+                log.info("eliminarAlbaranDependencias() - " + stmtPag.toString());
+                stmtPag.executeUpdate();
+                stmtPag.close();
+
+                String sqlDet = "delete from d_clie_albaranes_det_tbl where id_clie_albaran = ? and uid_actividad = ?";
+                PreparedStatement stmtDet = conexion.prepareStatement(sqlDet);
+                stmtDet.setLong(1, idClieAlbaran);
+                stmtDet.setString(2, uidActividad);
+                log.info("eliminarAlbaranDependencias() - " + stmtDet.toString());
+                stmtDet.executeUpdate();
+                stmtDet.close();
+
+                String sqlDocEnl = "delete from D_DOCUMENTOS_ENL_TBL where uid_actividad = ? and uid_documento = ?";
+                PreparedStatement stmtEnl = conexion.prepareStatement(sqlDocEnl);
+                stmtEnl.setString(1, uidActividad);
+                stmtEnl.setString(2, uidTicket);
+                log.info("eliminarAlbaranDependencias() - " + stmtEnl.toString());
+                stmtEnl.executeUpdate();
+                stmtEnl.close();
+
+                String sqlXTickets = "delete from x_tickets_tbl where uid_actividad = ? and uid_ticket = ?";
+                PreparedStatement stmtXTickets = conexion.prepareStatement(sqlXTickets);
+                stmtXTickets.setString(1, uidActividad);
+                stmtXTickets.setString(2, uidTicket);
+                log.info("eliminarAlbaranDependencias() - " + stmtXTickets.toString());
+                stmtXTickets.executeUpdate();
+                stmtXTickets.close();
+        }
 }

--- a/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/services/generacion/GenerarFtDeFsService.java
+++ b/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/services/generacion/GenerarFtDeFsService.java
@@ -70,6 +70,7 @@ public class GenerarFtDeFsService {
                         Document combinado = combinarTickets(fs, ft);
                         String xmlCorregido = marshalTicket(combinado);
                         TicketsDao.actualizarTicket(conexion, uidActividad, uidFt, xmlCorregido);
+                        TicketsDao.eliminarAlbaran(conexion, uidActividad, uidFt);
                     }
                 } catch (Exception e) {
                     log.error("Error procesando la fila para {}: {}", uidFt, e.getMessage(), e);


### PR DESCRIPTION
## Summary
- add DAO helpers to remove albaran records before deleting d_clie_albaranes_cab_tbl row
- invoke new method from GenerarFtDeFsService

## Testing
- `mvn -q test` *(fails: Non-resolvable POM due to blocked repository access)*

------
https://chatgpt.com/codex/tasks/task_e_6874fb2033d0832b91b677795693301c