### PR TITLE
Fix deletion of converted ticket records

### DIFF
--- a/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/TicketsDao.java
+++ b/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/TicketsDao.java
@@ -131,10 +131,11 @@ public class TicketsDao {
                 stmtEnl.executeUpdate();
                 stmtEnl.close();
 
-                String sqlXTickets = "delete from x_tickets_tbl where uid_actividad = ? and uid_ticket = ?";
+                String sqlXTickets = "delete from x_tickets_tbl where uid_actividad = ? and (uid_ticket = ? or uid_factura_completa = ?)";
                 PreparedStatement stmtXTickets = conexion.prepareStatement(sqlXTickets);
                 stmtXTickets.setString(1, uidActividad);
                 stmtXTickets.setString(2, uidTicket);
+                stmtXTickets.setString(3, uidTicket);
                 log.info("eliminarAlbaranDependencias() - " + stmtXTickets.toString());
                 stmtXTickets.executeUpdate();
                 stmtXTickets.close();


### PR DESCRIPTION
## Summary
- delete entries from `x_tickets_tbl` using either uid

## Testing
- `mvn -q -DskipTests install` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6874feafaa90832bbe9f6f533ec7d813