### PR TITLE
Fix compilation by setting Java 8 compiler

### DIFF
--- a/generar-ft-de-fs-services/pom.xml
+++ b/generar-ft-de-fs-services/pom.xml
@@ -70,6 +70,21 @@
                 </dependency>
 
         </dependencies>
-		
+
+
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <configuration>
+                                        <encoding>${project.build.sourceEncoding}</encoding>
+                                        <source>${java.version}</source>
+                                        <target>${java.version}</target>
+                                </configuration>
+                        </plugin>
+                </plugins>
+        </build>
+
 
 </project>


### PR DESCRIPTION
## Summary
- add maven compiler plugin in `generar-ft-de-fs-services` module

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM due to blocked remote repositories)*

------
https://chatgpt.com/codex/tasks/task_e_6878d18edc80832ba4aedaafcd4b6116