### PR TITLE
Guardar xml antiguo antes de actualizar tickets

### DIFF
--- a/generar-ft-de-fs-application/src/main/resources/application.yml
+++ b/generar-ft-de-fs-application/src/main/resources/application.yml
@@ -17,3 +17,5 @@ comerzzia:
     uid_actividad: "40f314f4-8a6e-4c38-82f6-a95a5c8dd0af"
     csv:
         path: ../correcciones.csv
+    xml:
+        backup-path: ../xml_antiguos


### PR DESCRIPTION
## Summary
- configure a folder to save old ticket XML files
- persist each original FT XML before it is updated

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a27b8c1fc832b8e63189dffd02024