### PR TITLE
Guardar XML antiguo de FT

### DIFF
--- a/generar-ft-de-fs-application/src/main/resources/application.yml
+++ b/generar-ft-de-fs-application/src/main/resources/application.yml
@@ -17,3 +17,6 @@ comerzzia:
     uid_actividad: "40f314f4-8a6e-4c38-82f6-a95a5c8dd0af"
     csv:
         path: ../correcciones.csv
+    xml:
+        backup:
+            dir: ../XMLantiguos


### PR DESCRIPTION
## Summary
- save original FT XMLs in `XMLantiguos` before replacement
- allow path configuration using `comerzzia.xml.backup.dir`
- add detailed debug logs around backup logic

## Testing
- `mvn -q -DskipTests package` *(fails: Blocked mirror for repositories)*
- `mvn -q test` *(fails: Blocked mirror for repositories)*

------
https://chatgpt.com/codex/tasks/task_e_687a2d796d00832babdf23a300855a2a