### PR TITLE
Improve log messages for easier reading

### DIFF
--- a/generar-ft-de-fs-application/src/main/java/com/comerzzia/bricodepot/generarftdefs/runner/GenerarFtDeFsRunner.java
+++ b/generar-ft-de-fs-application/src/main/java/com/comerzzia/bricodepot/generarftdefs/runner/GenerarFtDeFsRunner.java
@@ -24,10 +24,10 @@ public class GenerarFtDeFsRunner implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        log.debug("run() - Leyendo fichero CSV de correcciones desde " + csvPath);
+        log.info("Leyendo las correcciones del fichero CSV en " + csvPath);
         try (BufferedReader reader = new BufferedReader(new FileReader(csvPath))) {
             servicio.procesarCsv(reader);
-            log.debug("run() - Procesamiento de correcciones finalizado");
+            log.info("El procesamiento de las correcciones ha terminado");
         }
     }
 }

--- a/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/ProveedorConexion.java
+++ b/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/ProveedorConexion.java
@@ -32,9 +32,9 @@ public class ProveedorConexion {
     public Connection obtenerConexion() {
 
         if (conexion == null) {
-                log.debug("obtenerConexion() - Inicio de conexion a la BBDD");
-                log.debug("obtenerConexion() - URL: " + url);
-                log.debug("obtenerConexion() - USER: " + usuario);
+                log.info("Estableciendo conexión con la base de datos...");
+                log.info("URL de la base de datos: " + url);
+                log.info("Usuario de la base de datos: " + usuario);
                 try {
                         Class.forName(claseDb);
                         conexion = DriverManager.getConnection(url, usuario, contrasena);
@@ -47,7 +47,7 @@ public class ProveedorConexion {
                         log.error("obtenerConexion() - " + e.getClass().getName() + " - " + e.getLocalizedMessage(), e);
                 }
         } else {
-                log.debug("obtenerConexion() - Utilizando conexion existente");
+                log.info("Usando la conexión ya abierta.");
                 return conexion;
         }
 


### PR DESCRIPTION
## Summary
- provide friendlier logging in GenerarFtDeFsRunner
- simplify log texts in GenerarFtDeFsService
- clarify connection log messages in ProveedorConexion

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_687a43b790c8832ba662184e8c636458