### PR TITLE
Add detailed logging for cargo adjustment

### DIFF
--- a/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/TicketsDao.java
+++ b/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/TicketsDao.java
@@ -159,4 +159,57 @@ public class TicketsDao {
                 stmtXTickets.executeUpdate();
                 stmtXTickets.close();
         }
+
+        public static void ajustarMovimientosCaja(Connection conexion, String uidActividad, String uidDiarioCaja, String uidTicket)
+                        throws SQLException {
+                String selectSql = "select linea, cargo from d_caja_det_tbl "
+                                + "where uid_actividad = ? and uid_diario_caja = ? "
+                                + "and id_documento = ?";
+                PreparedStatement selectStmt = conexion.prepareStatement(selectSql);
+                selectStmt.setString(1, uidActividad);
+                selectStmt.setString(2, uidDiarioCaja);
+                selectStmt.setString(3, uidTicket);
+                log.debug("ajustarMovimientosCaja() - " + selectStmt.toString());
+                ResultSet rs = selectStmt.executeQuery();
+
+                Integer lineaPos = null;
+                Integer lineaNeg = null;
+                java.math.BigDecimal cargoPos = null;
+                java.math.BigDecimal cargoNeg = null;
+
+                while (rs.next()) {
+                        java.math.BigDecimal cargo = rs.getBigDecimal("cargo");
+                        int linea = rs.getInt("linea");
+                        if (cargo != null && cargo.compareTo(java.math.BigDecimal.ZERO) >= 0) {
+                                lineaPos = linea;
+                                cargoPos = cargo;
+                        } else if (cargo != null) {
+                                lineaNeg = linea;
+                                cargoNeg = cargo;
+                        }
+                }
+                rs.close();
+                selectStmt.close();
+
+                if (lineaPos != null && lineaNeg != null && cargoPos != null && cargoNeg != null) {
+                        java.math.BigDecimal nuevoCargo = cargoPos.add(cargoNeg.abs());
+                        log.info("ajustarMovimientosCaja() - linea positiva " + lineaPos +
+                                " cambia de " + cargoPos + " a " + nuevoCargo + " sumando abs(" + cargoNeg + ")");
+
+                        String updateSql = "update d_caja_det_tbl set cargo = ? where uid_actividad = ? and uid_diario_caja = ? and id_documento = ? and linea = ?";
+                        PreparedStatement updateStmt = conexion.prepareStatement(updateSql);
+                        updateStmt.setBigDecimal(1, nuevoCargo);
+                        updateStmt.setString(2, uidActividad);
+                        updateStmt.setString(3, uidDiarioCaja);
+                        updateStmt.setString(4, uidTicket);
+                        updateStmt.setInt(5, lineaPos);
+                        log.debug("ajustarMovimientosCaja() - " + updateStmt.toString());
+                        updateStmt.executeUpdate();
+                        updateStmt.close();
+                        log.debug("ajustarMovimientosCaja() - registro actualizado");
+                } else {
+                        log.warn("ajustarMovimientosCaja() - No se encontraron movimientos positivos y negativos para "
+                                + uidActividad + " / " + uidDiarioCaja + " / " + uidTicket);
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- log old and new cargo values when adjusting records in `d_caja_det_tbl`
- log which caja and ticket are used for the adjustment
- remove curly-brace placeholders from the logs

## Testing
- `mvn -q -DskipTests=true package` *(fails: Non-resolvable import POM)*


------
https://chatgpt.com/codex/tasks/task_e_6880c2783cdc832bbcb99589599195d8