### PR TITLE
Update caja adjustment logic

### DIFF
--- a/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/TicketsDao.java
+++ b/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/TicketsDao.java
@@ -164,7 +164,7 @@ public class TicketsDao {
                         throws SQLException {
                 String selectSql = "select linea, cargo from d_caja_det_tbl "
                                 + "where uid_actividad = ? and uid_diario_caja = ? "
-                                + "and id_documento = ?";
+                                + "and id_documento = ? order by linea";
                 PreparedStatement selectStmt = conexion.prepareStatement(selectSql);
                 selectStmt.setString(1, uidActividad);
                 selectStmt.setString(2, uidDiarioCaja);
@@ -181,11 +181,15 @@ public class TicketsDao {
                         java.math.BigDecimal cargo = rs.getBigDecimal("cargo");
                         int linea = rs.getInt("linea");
                         if (cargo != null && cargo.compareTo(java.math.BigDecimal.ZERO) >= 0) {
-                                lineaPos = linea;
-                                cargoPos = cargo;
+                                if (lineaPos == null) {
+                                        lineaPos = linea;
+                                        cargoPos = cargo;
+                                }
                         } else if (cargo != null) {
-                                lineaNeg = linea;
-                                cargoNeg = cargo;
+                                if (lineaNeg == null) {
+                                        lineaNeg = linea;
+                                        cargoNeg = cargo;
+                                }
                         }
                 }
                 rs.close();


### PR DESCRIPTION
## Summary
- adjust query ordering on `d_caja_det_tbl`
- modify caja adjustment logic to update the first positive movement only

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Blocked mirror for repositories)*

------
https://chatgpt.com/codex/tasks/task_e_6880d32c5d9c832b93cb2dbe43296cb9