### PR TITLE
Sync caja movements when converting FS to FT

### DIFF
--- a/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/TicketsDao.java
+++ b/generar-ft-de-fs-services/src/main/java/com/comerzzia/bricodepot/generarftdefs/persistence/TicketsDao.java
@@ -159,4 +159,60 @@ public class TicketsDao {
                 stmtXTickets.executeUpdate();
                 stmtXTickets.close();
         }
+
+        public static ResultSet consultarMovimientosCaja(Connection conexion, String uidActividad,
+                        String uidDiarioCaja, String idDocumento) throws SQLException {
+                String sql = "select * from d_caja_det_tbl where uid_actividad = ? and uid_diario_caja = ? and id_documento = ? order by linea";
+                PreparedStatement stmt = conexion.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY,
+                                ResultSet.CONCUR_READ_ONLY);
+                stmt.setString(1, uidActividad);
+                stmt.setString(2, uidDiarioCaja);
+                stmt.setString(3, idDocumento);
+                log.info("consultarMovimientosCaja() - " + stmt.toString());
+                return stmt.executeQuery();
+        }
+
+        public static void borrarMovimientosCaja(Connection conexion, String uidActividad, String uidDiarioCaja,
+                        String idDocumento) throws SQLException {
+                String sql = "delete from d_caja_det_tbl where uid_actividad = ? and uid_diario_caja = ? and id_documento = ?";
+                PreparedStatement stmt = conexion.prepareStatement(sql);
+                stmt.setString(1, uidActividad);
+                stmt.setString(2, uidDiarioCaja);
+                stmt.setString(3, idDocumento);
+                log.info("borrarMovimientosCaja() - " + stmt.toString());
+                stmt.executeUpdate();
+                stmt.close();
+        }
+
+        public static void insertarMovimientoCaja(Connection conexion, String uidActividad, String uidDiarioCaja,
+                        int linea, java.sql.Timestamp fecha, java.math.BigDecimal cargo, java.math.BigDecimal abono,
+                        String concepto, String documento, String codmedpag, String idDocumento,
+                        String codconceptoMov, Long idTipoDocumento, String uidTransaccionDet, String coddivisa,
+                        java.math.BigDecimal tipoDeCambio, String usuario) throws SQLException {
+                String sql = "insert into d_caja_det_tbl (uid_actividad, uid_diario_caja, linea, fecha, cargo, abono, concepto, documento, codmedpag, id_documento, codconcepto_mov, id_tipo_documento, uid_transaccion_det, coddivisa, tipo_de_cambio, usuario) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+                PreparedStatement stmt = conexion.prepareStatement(sql);
+                stmt.setString(1, uidActividad);
+                stmt.setString(2, uidDiarioCaja);
+                stmt.setInt(3, linea);
+                stmt.setTimestamp(4, fecha);
+                stmt.setBigDecimal(5, cargo);
+                stmt.setBigDecimal(6, abono);
+                stmt.setString(7, concepto);
+                stmt.setString(8, documento);
+                stmt.setString(9, codmedpag);
+                stmt.setString(10, idDocumento);
+                stmt.setString(11, codconceptoMov);
+                if (idTipoDocumento != null) {
+                        stmt.setLong(12, idTipoDocumento);
+                } else {
+                        stmt.setNull(12, java.sql.Types.BIGINT);
+                }
+                stmt.setString(13, uidTransaccionDet);
+                stmt.setString(14, coddivisa);
+                stmt.setBigDecimal(15, tipoDeCambio);
+                stmt.setString(16, usuario);
+                log.info("insertarMovimientoCaja() - " + stmt.toString());
+                stmt.executeUpdate();
+                stmt.close();
+        }
 }


### PR DESCRIPTION
## Summary
- query `d_caja_det_tbl` and copy FS movements to FT
- add DB helper methods to read/insert/delete movement records
- keep FT concept and document fields when recreating movements

## Testing
- `mvn -q -DskipTests package` *(fails: Blocked mirror for repositories)*

------
https://chatgpt.com/codex/tasks/task_e_6881fcfc4ddc832b8989670b15af9af4